### PR TITLE
MSR-4969

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 vendor/
 composer.lock
+.idea
+.phpunit.result.cache
+composer.phar

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php":            ">=5.3.3",
         "ext-SPL":        "*",
-        "doctrine/lexer": "~1.0"
+        "doctrine/lexer": "^1.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit":               ">=4.8",

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,13 @@
     ],
     "license": "MIT",
     "require": {
-        "php":            ">=5.3.3",
+        "php":            ">=8.0",
         "ext-SPL":        "*",
         "doctrine/lexer": "^1.0 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit":               ">=4.8",
-        "codeclimate/php-test-reporter": "dev-master"
-    },
+
+   },
     "autoload": {
         "psr-0": {
             "CrEOF\\Geo\\WKT": "lib/"

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
     ],
     "license": "MIT",
     "require": {
-        "php":            ">=8.0",
+        "php":            ">=8.1",
         "ext-SPL":        "*",
-        "doctrine/lexer": "^1.0 || ^3.0"
+        "doctrine/lexer": "^3.0"
     },
     "require-dev": {
-
-   },
+        "phpunit/phpunit": "^10.5 || ^11.0"
+    },
     "autoload": {
         "psr-0": {
             "CrEOF\\Geo\\WKT": "lib/"

--- a/lib/CrEOF/Geo/WKT/Lexer.php
+++ b/lib/CrEOF/Geo/WKT/Lexer.php
@@ -95,8 +95,8 @@ class Lexer extends AbstractLexer
     protected function getType(&$value)
     {
         if (is_numeric($value)) {
-
-            if (is_int($value)) {
+            if (strpos($value, '.') === false && stripos($value, 'e') === false) {
+                $value = (int) $value;
                 return self::T_INTEGER;
             }
 

--- a/lib/CrEOF/Geo/WKT/Lexer.php
+++ b/lib/CrEOF/Geo/WKT/Lexer.php
@@ -84,7 +84,7 @@ class Lexer extends AbstractLexer
      */
     public function value()
     {
-        return $this->token['value'];
+        return $this->token->value;
     }
 
     /**
@@ -95,7 +95,6 @@ class Lexer extends AbstractLexer
     protected function getType(&$value)
     {
         if (is_numeric($value)) {
-            $value += 0;
 
             if (is_int($value)) {
                 return self::T_INTEGER;

--- a/lib/CrEOF/Geo/WKT/Parser.php
+++ b/lib/CrEOF/Geo/WKT/Parser.php
@@ -349,7 +349,7 @@ class Parser
      */
     protected function match($token)
     {
-        $lookaheadType = $this->lexer->lookahead->type;
+        $lookaheadType = $this->lexer->lookahead?->type;
 
         if ($lookaheadType !== $token && ($token !== Lexer::T_TYPE || $lookaheadType <= Lexer::T_TYPE)) {
             throw $this->syntaxError($this->lexer->getLiteral($token));
@@ -372,7 +372,7 @@ class Parser
         $found    = null === $this->lexer->lookahead ? 'end of string.' : sprintf('"%s"', $token->value);
         $message  = sprintf(
             '[Syntax Error] line 0, col %d: Error: %s %s in value "%s"',
-            $token->position ?? '-1',
+            $token?->position ?? '-1',
             $expected,
             $found,
             $this->input

--- a/lib/CrEOF/Geo/WKT/Parser.php
+++ b/lib/CrEOF/Geo/WKT/Parser.php
@@ -139,7 +139,7 @@ class Parser
         $this->type = $type;
 
         if ($this->lexer->isNextTokenAny(array(Lexer::T_Z, Lexer::T_M, Lexer::T_ZM))) {
-            $this->match($this->lexer->lookahead['type']);
+            $this->match($this->lexer->lookahead->type);
 
             $this->dimension = $this->lexer->value();
         }
@@ -349,7 +349,7 @@ class Parser
      */
     protected function match($token)
     {
-        $lookaheadType = $this->lexer->lookahead['type'];
+        $lookaheadType = $this->lexer->lookahead->type;
 
         if ($lookaheadType !== $token && ($token !== Lexer::T_TYPE || $lookaheadType <= Lexer::T_TYPE)) {
             throw $this->syntaxError($this->lexer->getLiteral($token));
@@ -369,10 +369,10 @@ class Parser
     {
         $expected = sprintf('Expected %s, got', $expected);
         $token    = $this->lexer->lookahead;
-        $found    = null === $this->lexer->lookahead ? 'end of string.' : sprintf('"%s"', $token['value']);
+        $found    = null === $this->lexer->lookahead ? 'end of string.' : sprintf('"%s"', $token->value);
         $message  = sprintf(
             '[Syntax Error] line 0, col %d: Error: %s %s in value "%s"',
-            isset($token['position']) ? $token['position'] : '-1',
+            $token->position ?? '-1',
             $expected,
             $found,
             $this->input

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
         backupGlobals="false"
         colors="true"
         bootstrap="./vendor/autoload.php"
@@ -13,13 +13,13 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory suffix=".php">lib</directory>
-            <exclude>
-                <directory>tests</directory>
-                <directory>vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>tests</directory>
+            <directory>vendor</directory>
+        </exclude>
+    </source>
 </phpunit>

--- a/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
@@ -24,6 +24,8 @@
 namespace CrEOF\Geo\WKT\Tests;
 
 use CrEOF\Geo\WKT\Lexer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Lexer tests
@@ -31,14 +33,9 @@ use CrEOF\Geo\WKT\Lexer;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-class LexerTest extends \PHPUnit_Framework_TestCase
+class LexerTest extends TestCase
 {
-    /**
-     * @param       $value
-     * @param array $expected
-     *
-     * @dataProvider tokenData
-     */
+    #[DataProvider('tokenData')]
     public function testTokenRecognition($value, array $expected)
     {
         $lexer = new Lexer($value);
@@ -48,9 +45,9 @@ class LexerTest extends \PHPUnit_Framework_TestCase
 
             $actual = $lexer->lookahead;
 
-            $this->assertEquals($token[0], $actual['type']);
-            $this->assertEquals($token[1], $actual['value']);
-            $this->assertEquals($token[2], $actual['position']);
+            $this->assertEquals($token[0], $actual->type);
+            $this->assertEquals($token[1], $actual->value);
+            $this->assertEquals($token[2], $actual->position);
         }
     }
 
@@ -58,7 +55,7 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     {
         $lexer = new Lexer();
 
-        foreach ($this->tokenData() as $name => $testData) {
+        foreach (static::tokenData() as $name => $testData) {
             $lexer->setInput($testData['value']);
 
             foreach ($testData['expected'] as $token) {
@@ -66,9 +63,9 @@ class LexerTest extends \PHPUnit_Framework_TestCase
 
                 $actual = $lexer->lookahead;
 
-                $this->assertEquals($token[0], $actual['type']);
-                $this->assertEquals($token[1], $actual['value']);
-                $this->assertEquals($token[2], $actual['position']);
+                $this->assertEquals($token[0], $actual->type);
+                $this->assertEquals($token[1], $actual->value);
+                $this->assertEquals($token[2], $actual->position);
             }
         }
     }
@@ -76,7 +73,7 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     /**
      * @return array
      */
-    public function tokenData()
+    public static function tokenData()
     {
         return array(
             'POINT' => array(

--- a/tests/CrEOF/Geo/WKT/Tests/ParserTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/ParserTest.php
@@ -26,6 +26,8 @@ namespace CrEOF\Geo\WKT\Tests;
 use CrEOF\Geo\WKT\Exception\ExceptionInterface;
 use CrEOF\Geo\WKT\Exception\UnexpectedValueException;
 use CrEOF\Geo\WKT\Parser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Basic parser tests
@@ -33,20 +35,16 @@ use CrEOF\Geo\WKT\Parser;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-class ParserTest extends \PHPUnit_Framework_TestCase
+class ParserTest extends TestCase
 {
-    /**
-     * @param string $value
-     * @param array  $expected
-     *
-     * @dataProvider parserTestData
-     */
+    #[DataProvider('parserTestData')]
     public function testParser($value, $expected)
     {
         $parser = new Parser($value);
 
         if ($expected instanceof ExceptionInterface) {
-            $this->setExpectedException(get_class($expected), $expected->getMessage());
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
         }
 
         $actual = $parser->parse();
@@ -58,24 +56,30 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     {
         $parser = new Parser();
 
-        foreach ($this->parserTestData() as $name => $testData) {
+        foreach (static::parserTestData() as $name => $testData) {
             $value    = $testData['value'];
             $expected = $testData['expected'];
 
             if ($expected instanceof ExceptionInterface) {
-                $this->setExpectedException(get_class($expected), $expected->getMessage());
+                try {
+                    $parser->parse($value);
+                    $this->fail(sprintf('Expected exception %s was not thrown for dataset "%s"', get_class($expected), $name));
+                } catch (ExceptionInterface $e) {
+                    $this->assertInstanceOf(get_class($expected), $e, 'Dataset "' . $name . '"');
+                    $this->assertSame($expected->getMessage(), $e->getMessage(), 'Dataset "' . $name . '"');
+                }
+            } else {
+                $actual = $parser->parse($value);
+
+                $this->assertEquals($expected, $actual, 'Failed dataset "' . $name . '"');
             }
-
-            $actual = $parser->parse($value);
-
-            $this->assertEquals($expected, $actual, 'Failed dataset "'. $name . '"');
         }
     }
 
     /**
      * @return array[]
      */
-    public function parserTestData()
+    public static function parserTestData()
     {
         return array(
             'testParsingGarbage' => array(


### PR DESCRIPTION
  Fix Lexer::getType() integer detection: is_int() on regex-matched strings
  is always false; replace with strpos/stripos check and cast $value to int.
  This also fixes SRID parsing which requires T_INTEGER tokens.

  Use null-safe operator (?->) in Parser::match() and syntaxError() to
  eliminate PHP 8.x warnings when lookahead is null at end of input.

  Update dependencies: require doctrine/lexer ^3.0 (drops broken v1 support),
  add phpunit/phpunit ^10.5||^11.0 to require-dev, bump PHP floor to >=8.1.

  Modernise test suite for PHPUnit 11: update base class, replace
  setExpectedException() with expectException(), convert @dataProvider
  doc-comments to #[DataProvider] attributes, update Token array access
  to object property access, make data providers static.

  Update phpunit.xml.dist to PHPUnit 10+ schema (<source> replaces <whitelist>).


\+ Laravel 10 upgrade

<img width="1040" height="360" alt="image" src="https://github.com/user-attachments/assets/b90e46ac-f53e-422f-9da0-fbfe75810d4e" />
<img width="1020" height="335" alt="image" src="https://github.com/user-attachments/assets/8a38a669-3463-4cb2-8dd4-3935b4150c7d" />
